### PR TITLE
vigojug.org was not accesible (missing CNAME)

### DIFF
--- a/assets/CNAME
+++ b/assets/CNAME
@@ -1,0 +1,1 @@
+www.vigojug.org


### PR DESCRIPTION
Lo pisé con la web y no lo volví a crear en la estructura.